### PR TITLE
xlsx multiple requests fix

### DIFF
--- a/src/components/file-viewer.jsx
+++ b/src/components/file-viewer.jsx
@@ -23,12 +23,14 @@ class FileViewer extends Component {
     this.state = {
       loading: true,
     };
+    this.Driver
   }
 
   componentDidMount() {
     const container = document.getElementById('pg-viewer');
     const height = container ? container.clientHeight : 0;
     const width = container ? container.clientWidth : 0;
+    this.Driver = this.getDriver(this.props);
     this.setState({ height, width });
   }
 
@@ -71,11 +73,11 @@ class FileViewer extends Component {
   }
 
   render() {
-    const Driver = this.getDriver(this.props);
+    let Driver = this.Driver
     return (
       <div className="pg-viewer-wrapper">
         <div className="pg-viewer" id="pg-viewer">
-          <Driver {...this.props} width={this.state.width} height={this.state.height} />
+          {Driver ? <Driver {...this.props} width={this.state.width} height={this.state.height} /> : null}
         </div>
       </div>
     );


### PR DESCRIPTION
Opening xlsx files results in multiple XMLHttpRequests being generated.  This occurs because the `getDriver()` call lives in `render()` which can be called quite frequently.  
The XMLHttpRequest should only be created once.  To facilitate this the `getDriver() `call has been moved to `componentDidMount()`.